### PR TITLE
Added layer to sprite render component

### DIFF
--- a/Enigma/src/Panels/ScenePanel.cpp
+++ b/Enigma/src/Panels/ScenePanel.cpp
@@ -420,8 +420,21 @@ namespace Labyrinth {
 			}
 		});
 
-		DrawComponent<SpriteRendererComponent>("Sprite Renderer", mSelectedEntity, [](auto& component)
+		DrawComponent<SpriteRendererComponent>("Sprite Renderer", mSelectedEntity, [&](auto& component)
 		{
+			int layerVal = component.layer;
+			if (ImGui::InputInt("Layer", &layerVal))
+			{
+				if (layerVal < 0) layerVal = 0;
+				if (layerVal > component.MaxLayers) layerVal = component.MaxLayers;
+
+				if (layerVal != component.layer)
+				{
+					component.layer = layerVal;
+					mSelectedEntity.getComponent<TransformComponent>().translation.z = component.getNLayer();
+				}
+			}
+
 			ImGui::ColorEdit4("Colour", glm::value_ptr(component.colour));
 
 			ImGui::Button("Texture", ImVec2(100.0f, 0.0f));

--- a/Labyrinth/src/Labyrinth/Scene/Components.h
+++ b/Labyrinth/src/Labyrinth/Scene/Components.h
@@ -170,28 +170,26 @@ namespace Labyrinth {
 
 		TexType type = TexType::None;
 
+		uint8_t layer = 0;
+		static const uint8_t MaxLayers = std::numeric_limits<uint8_t>::max();
+
 		glm::vec4 colour{ 1.0f, 1.0f, 1.0f, 1.0f };
 		TextureComponent texture;
 		bool tile = false;
 		float tilingFactor = 1.0f;
 
 		SpriteRendererComponent() = default;
-		//SpriteRendererComponent(const SpriteRendererComponent& other)
-		//{
-		//	type = other.type;
-		//	colour = other.colour;
-		//	memcpy(&texture, &other.texture, sizeof(TextureComponent));
-		//	tile = other.tile;
-		//	tilingFactor = other.tilingFactor;
-		//}
-		SpriteRendererComponent(const glm::vec4& rgba)
-			: type(TexType::None), colour(rgba), tile(false) {}
-		SpriteRendererComponent(Ref<Texture2D> tex, float tf)
-			: type(TexType::Texture), texture(tex), tilingFactor(tf), tile(false) {}
-		SpriteRendererComponent(Ref<SubTexture2D> subtex, float tf)
-			: type(TexType::Tile), texture(subtex), tilingFactor(tf), tile(true) {}
+		SpriteRendererComponent(const glm::vec4& rgba, uint8_t layer = 0)
+			: type(TexType::None), layer(layer), colour(rgba), tile(false) {}
+		SpriteRendererComponent(Ref<Texture2D> tex, float tf, uint8_t layer = 0)
+			: type(TexType::Texture), layer(layer), texture(tex), tilingFactor(tf), tile(false) {}
+		SpriteRendererComponent(Ref<SubTexture2D> subtex, float tf, uint8_t layer = 0)
+			: type(TexType::Tile), layer(layer), texture(subtex), tilingFactor(tf), tile(true) {}
 
-		bool hasTex() { return type != TexType::None; }
+		bool hasTex() const { return type != TexType::None; }
+
+		// Get normalised layer value
+		float getNLayer() const { return (Cast<float>(layer) / Cast<float>(MaxLayers)); }
 	};
 
 	struct TagComponent

--- a/Labyrinth/src/Labyrinth/Scene/Scene.cpp
+++ b/Labyrinth/src/Labyrinth/Scene/Scene.cpp
@@ -318,6 +318,9 @@ namespace Labyrinth {
 	template<>
 	void Scene::onComponentAdded<SpriteRendererComponent>(Entity entity, SpriteRendererComponent& component)
 	{
+		// Overwrite transform component z value using render layer value
+		auto& trans = entity.getComponent<TransformComponent>().translation;
+		trans.z = component.getNLayer();
 	}
 
 	template<>

--- a/Labyrinth/src/Labyrinth/Scene/Serialiser.cpp
+++ b/Labyrinth/src/Labyrinth/Scene/Serialiser.cpp
@@ -198,6 +198,8 @@ namespace Labyrinth {
 		BeginObject("SpriteRendererComponent");
 
 		ObjectProperty("Type", Cast<int>(srComponent.type));
+		ObjectProperty("Layer", srComponent.layer);
+
 		ObjectProperty("Colour", srComponent.colour);
 
 		switch (srComponent.type)
@@ -462,6 +464,8 @@ namespace Labyrinth {
 			auto& src = entity.addComponent<SpriteRendererComponent>();
 
 			src.type = (SpriteRendererComponent::TexType)spriteRendererComponent["Type"].as<int>();
+			src.layer = spriteRendererComponent["Layer"].as<uint8_t>();
+
 			src.colour = spriteRendererComponent["Colour"].as<glm::vec4>();
 
 			switch (src.type)


### PR DESCRIPTION
For issue #23:

Added layer value to the sprite component. This value is an unsigned char so ranges from 0 to 255. Setting this value will set the z component of the transform component to the layer value normalised between 0 and 1. This will cause layers to be sorted according to their z value. 

This allows users to easily decide at runtime the order that sprites should be drawn in. 